### PR TITLE
Deploy all VisualizerSource dll to "netstandard2.0" folder

### DIFF
--- a/src/ExceptionVisualizer/ExceptionVisualizer.csproj
+++ b/src/ExceptionVisualizer/ExceptionVisualizer.csproj
@@ -20,22 +20,18 @@
 	<ItemGroup>
 		<Page Remove="ExceptionUserControl.xaml" />
 		<EmbeddedResource Include="ExceptionUserControl.xaml" LogicalName="$(RootNamespace).ExceptionUserControl.xaml" />
-
-		<Content Include="..\ExceptionVisualizerSource\bin\$(Configuration)\netstandard2.0\ExceptionVisualizerSource.dll" Link="netstandard2.0\ExceptionVisualizerSource.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\ExceptionVisualizerSource\bin\$(Configuration)\netstandard2.0\Ben.Demystifier.dll" Link="netstandard2.0\Ben.Demystifier.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-
-		<None Remove="icon.png" />
-		<Content Include="icon.png">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</Content>
+		<Content Include="icon.png" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\ExceptionVisualizerSource\ExceptionVisualizerSource.csproj" />
 	</ItemGroup>
 
+	<Target Name="AddVisualizerSourceDllsToContent" AfterTargets="CopyFilesToOutputDirectory" BeforeTargets="GetVsixSourceItems">
+		<ItemGroup>
+			<VisualizerSourceDlls Include="..\ExceptionVisualizerSource\bin\$(Configuration)\netstandard2.0\*.dll" />
+			<Content Include="@(VisualizerSourceDlls)" Link="netstandard2.0\%(Filename)%(Extension)" />
+		</ItemGroup>
+	</Target>
+	
 </Project>


### PR DESCRIPTION
Fix the Issue https://github.com/elmahio/ExceptionVisualizer/issues/8

Deploy all necessary dependencies to the `netstandard2.0` folder. Then if the Debuggee doesn't have some of the dependencies, they will be loaded together with the `ExceptionVisualizerSource.dll`.